### PR TITLE
Configurable SDK providers, debug output, and Godot Engine compatibility.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: "Base URL of where to find macOS SDKs"
     required: false
     default: "https://github.com/joseluisq/macosx-sdks/releases/download"
+  debug: 
+    description: "Enable osxcross debug output"
+    required: false
+    default: "0"
 
 runs:
   using: "composite"
@@ -94,7 +98,7 @@ runs:
         UNATTENDED: "yes"
       run: |
         cd "$GITHUB_ACTION_PATH/osxcross"
-        OCDEBUG=1 bash ./build.sh
+        OCDEBUG=${{ inputs.debug }} bash ./build.sh
 
     - shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -93,10 +93,6 @@ runs:
         SDK_VERSION: "${{ inputs.osx-version }}"
         UNATTENDED: "yes"
       run: |
-        pwd
-        ls -lah 
-        echo "$GITHUB_ACTION_PATH/osxcross"
-        echo $OSXCROSS_FOLDER
         cd "$GITHUB_ACTION_PATH/osxcross"
         bash ./build.sh
 

--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
 
         # Check setup for osx version
         echo "::group::Fetching macosx SDK"
-        FILE_NAME="MacOSX${{ inputs.osx-version }}.sdk.tar.xz"
+        FILE_NAME="MacOSX${{ inputs.osx-version }}.sdk.tar.xz" # *OSX*13.0*sdk*
 
         # Check sdk-url for release
         wget -nc "${{ inputs.sdk-url }}/${{ inputs.osx-version }}/${FILE_NAME}" -O "$OSXCROSS_FOLDER/tarballs/${FILE_NAME}"
@@ -94,7 +94,7 @@ runs:
         UNATTENDED: "yes"
       run: |
         cd "$GITHUB_ACTION_PATH/osxcross"
-        bash ./build.sh
+        OCDEBUG=1 bash ./build.sh
 
     - shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -124,3 +124,4 @@ runs:
         echo "Setting: CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS=\"-C linker=${AR_FILE} -C linker=${LINKER_FILE} -C link-arg=-undefined -C link-arg=dynamic_lookup\""
         echo "CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=${LINKER_FILE}" >> $GITHUB_ENV
         echo "CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS=-Car=${AR_FILE},-Clink-arg=-undefined,-Clink-arg=dynamic_lookup" >> $GITHUB_ENV
+        echo "OSXCROSS_ROOT=$OSXCROSS_FOLDER" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   osx-version:
     description: "Version of osx to use."
     required: true
+  sdk-url: 
+    description: "Base URL of where to find macOS SDKs"
+    required: true
 
 runs:
   using: "composite"
@@ -66,8 +69,8 @@ runs:
         echo "::group::Fetching macosx SDK"
         FILE_NAME="MacOSX${{ inputs.osx-version }}.sdk.tar.xz"
 
-        # Check joseluisq/macosx-sdks for release
-        wget -nc "https://github.com/joseluisq/macosx-sdks/releases/download/${{ inputs.osx-version }}/${FILE_NAME}" -O "$OSXCROSS_FOLDER/tarballs/${FILE_NAME}"
+        # Check sdk-url for release
+        wget -nc "${{ inputs.sdk-url }}/${{ inputs.osx-version }}/${FILE_NAME}" -O "$OSXCROSS_FOLDER/tarballs/${FILE_NAME}"
         echo "::endgroup::"
 
         echo "OSXCROSS_TARGET=${OSXCROSS_FOLDER}/target" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
   debug: 
     description: "Enable osxcross debug output"
     required: false
-    default: 0
+    default: false
 
 runs:
   using: "composite"
@@ -80,19 +80,24 @@ runs:
 
         echo "OSXCROSS_TARGET=${OSXCROSS_FOLDER}/target" >> $GITHUB_ENV
 
-    - uses: actions/cache@v3
-      id: cache
+    - name: Restore Cached Osxcross Build 
+      id: cache-restore
+    - uses: actions/cache/restore@v3.2.3
       with:
-        key: ${{ runner.os }}-osxcross-${{ inputs.osx-version }}
         path: |
           ~/.cargo/registry
           ~/.cargo/git
           ${{ env.OSXCROSS_TARGET }}
           ${{ env.OSXCROSS_FOLDER }}/target/bi
-          
+        key: ${{ runner.os }}-osxcross-${{ inputs.osx-version }}
+
+    - name: Configure Osxcross Build Debug Output
+      if: inputs.debug == 'true'
+      run: echo "OCDEBUG=1" >> $GITHUB_ENV
 
     - shell: bash
-      if: steps.cache.outputs.cache-hit != 'true'
+      id: build-osxcross
+      if: steps.cache-restore.outputs.cache-hit != 'true'
       env:
         SDK_VERSION: "${{ inputs.osx-version }}"
         UNATTENDED: "yes"
@@ -100,8 +105,20 @@ runs:
         cd "$GITHUB_ACTION_PATH/osxcross"
         pwd
         ls -lah 
-        OCDEBUG=${{ inputs.debug }} bash ./build.sh
+        bash ./build.sh
 
+    - name: Cache Osxcross Build 
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      id: cache-save
+    - uses: actions/cache/save@v3.2.3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          ${{ env.OSXCROSS_TARGET }}
+          ${{ env.OSXCROSS_FOLDER }}/target/bi
+        key: ${{ runner.os }}-osxcross-${{ inputs.osx-version }}
+          
     - shell: bash
       run: |
         echo "::group::Setting up Bin files"

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
   debug: 
     description: "Enable osxcross debug output"
     required: false
-    default: "0"
+    default: 0
 
 runs:
   using: "composite"
@@ -72,7 +72,7 @@ runs:
 
         # Check setup for osx version
         echo "::group::Fetching macosx SDK"
-        FILE_NAME="MacOSX${{ inputs.osx-version }}.sdk.tar.xz" # *OSX*13.0*sdk*
+        FILE_NAME="MacOSX${{ inputs.osx-version }}.sdk.tar.xz"
 
         # Check sdk-url for release
         wget -nc "${{ inputs.sdk-url }}/${{ inputs.osx-version }}/${FILE_NAME}" -O "$OSXCROSS_FOLDER/tarballs/${FILE_NAME}"
@@ -98,6 +98,8 @@ runs:
         UNATTENDED: "yes"
       run: |
         cd "$GITHUB_ACTION_PATH/osxcross"
+        pwd
+        ls -lah 
         OCDEBUG=${{ inputs.debug }} bash ./build.sh
 
     - shell: bash

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,8 @@ inputs:
     required: true
   sdk-url: 
     description: "Base URL of where to find macOS SDKs"
-    required: true
+    required: false
+    default: "https://github.com/joseluisq/macosx-sdks/releases/download"
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,8 @@ runs:
           ${{ env.OSXCROSS_FOLDER }}/target/bi
         key: ${{ runner.os }}-osxcross-${{ inputs.osx-version }}
 
-    - name: Configure Osxcross Build Debug Output
+    - shell: bash 
+      name: Configure Osxcross Build Debug Output
       if: inputs.debug == 'true'
       run: echo "OCDEBUG=1" >> $GITHUB_ENV
 

--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ runs:
 
     - name: Restore Cached Osxcross Build 
       id: cache-restore
-    - uses: actions/cache/restore@v3.2.3
+      uses: actions/cache/restore@v3.2.3
       with:
         path: |
           ~/.cargo/registry
@@ -110,7 +110,7 @@ runs:
     - name: Cache Osxcross Build 
       if: steps.cache-restore.outputs.cache-hit != 'true'
       id: cache-save
-    - uses: actions/cache/save@v3.2.3
+      uses: actions/cache/save@v3.2.3
       with:
         path: |
           ~/.cargo/registry

--- a/action.yml
+++ b/action.yml
@@ -93,6 +93,10 @@ runs:
         SDK_VERSION: "${{ inputs.osx-version }}"
         UNATTENDED: "yes"
       run: |
+        pwd
+        ls -lah 
+        echo "$GITHUB_ACTION_PATH/osxcross"
+        echo $OSXCROSS_FOLDER
         cd "$GITHUB_ACTION_PATH/osxcross"
         bash ./build.sh
 


### PR DESCRIPTION
This pull request introduces the following changes.

## New Actions Inputs

- `sdk-url`: Allows the base URL of an SDK repository to be specified. I needed this because the default (`joseluisq/macosx-sdks`) did not have a 13.0 SDK available. If unspecified, the previous default location will be used. 

- `debug`: Optionally allows you to enable osxcross debug output by setting `OCDEBUG`.

## Other Changes

- Export `OSXCROSS_ROOT` in the `GITHUB_ENV`, enabling support for cross-compilation with Godot Engine ([docs](https://docs.godotengine.org/en/3.1/development/compiling/compiling_for_osx.html#cross-compiling)).