### PR TITLE
Permission denied on chmod without sudo command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,7 @@ runs:
           echo "Error! Failed to find ${OSXCROSS_FOLDER}/target/bin folder!"
           exit 1
         else
-          chmod +x $OSXCROSS_FOLDER/target/bin/*
+          sudo chmod +x $OSXCROSS_FOLDER/target/bin/*
         fi
         echo "::endgroup::"
 

--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,13 @@ runs:
           echo "Error! Failed to find ${OSXCROSS_FOLDER}/target/bin folder!"
           exit 1
         else
-          sudo chmod +x $OSXCROSS_FOLDER/target/bin/*
+
+    if hash sudo 2>/dev/null; then
+        sudo chmod +x $OSXCROSS_FOLDER/target/bin/*
+    else
+        chmod +x $OSXCROSS_FOLDER/target/bin/*
+    fi
+          
         fi
         echo "::endgroup::"
 


### PR DESCRIPTION
When executing the chmod command without sudo, GitHub will return a "permission denied" error